### PR TITLE
feat: Add 30 Material Design dropdowns

### DIFF
--- a/assets/dropdowns.html
+++ b/assets/dropdowns.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>30 Dropdowns</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <script type="importmap">
+    {
+      "imports": {
+        "@material/web/": "https://esm.run/@material/web/"
+      }
+    }
+    </script>
+    <script type="module">
+        import '@material/web/all.js';
+        import {styles as typescaleStyles} from '@material/web/typography/md-typescale-styles.js';
+        document.adoptedStyleSheets.push(typescaleStyles.styleSheet);
+    </script>
+    <style>
+        body {
+            font-family: 'Roboto', sans-serif;
+            padding: 20px;
+        }
+        md-outlined-select {
+            min-width: 200px;
+            margin-bottom: 20px;
+        }
+    </style>
+</head>
+<body>
+    <h1>30 Material Design Dropdowns</h1>
+
+    <md-outlined-select label="Select an Animal 1">
+      <md-select-option value="lion"><div slot="headline">Lion</div></md-select-option>
+      <md-select-option value="tiger"><div slot="headline">Tiger</div></md-select-option>
+      <md-select-option value="bear"><div slot="headline">Bear</div></md-select-option>
+      <md-select-option value="elephant"><div slot="headline">Elephant</div></md-select-option>
+      <md-select-option value="giraffe"><div slot="headline">Giraffe</div></md-select-option>
+      <md-select-option value="zebra"><div slot="headline">Zebra</div></md-select-option>
+      <md-select-option value="monkey"><div slot="headline">Monkey</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a City 2">
+      <md-select-option value="new-york"><div slot="headline">New York</div></md-select-option>
+      <md-select-option value="london"><div slot="headline">London</div></md-select-option>
+      <md-select-option value="paris"><div slot="headline">Paris</div></md-select-option>
+      <md-select-option value="tokyo"><div slot="headline">Tokyo</div></md-select-option>
+      <md-select-option value="sydney"><div slot="headline">Sydney</div></md-select-option>
+      <md-select-option value="dubai"><div slot="headline">Dubai</div></md-select-option>
+      <md-select-option value="moscow"><div slot="headline">Moscow</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Fruit 3">
+      <md-select-option value="apple"><div slot="headline">Apple</div></md-select-option>
+      <md-select-option value="banana"><div slot="headline">Banana</div></md-select-option>
+      <md-select-option value="orange"><div slot="headline">Orange</div></md-select-option>
+      <md-select-option value="grape"><div slot="headline">Grape</div></md-select-option>
+      <md-select-option value="strawberry"><div slot="headline">Strawberry</div></md-select-option>
+      <md-select-option value="blueberry"><div slot="headline">Blueberry</div></md-select-option>
+      <md-select-option value="mango"><div slot="headline">Mango</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Color 4">
+      <md-select-option value="red"><div slot="headline">Red</div></md-select-option>
+      <md-select-option value="green"><div slot="headline">Green</div></md-select-option>
+      <md-select-option value="blue"><div slot="headline">Blue</div></md-select-option>
+      <md-select-option value="yellow"><div slot="headline">Yellow</div></md-select-option>
+      <md-select-option value="purple"><div slot="headline">Purple</div></md-select-option>
+      <md-select-option value="orange"><div slot="headline">Orange</div></md-select-option>
+      <md-select-option value="black"><div slot="headline">Black</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Planet 5">
+      <md-select-option value="mercury"><div slot="headline">Mercury</div></md-select-option>
+      <md-select-option value="venus"><div slot="headline">Venus</div></md-select-option>
+      <md-select-option value="earth"><div slot="headline">Earth</div></md-select-option>
+      <md-select-option value="mars"><div slot="headline">Mars</div></md-select-option>
+      <md-select-option value="jupiter"><div slot="headline">Jupiter</div></md-select-option>
+      <md-select-option value="saturn"><div slot="headline">Saturn</div></md-select-option>
+      <md-select-option value="uranus"><div slot="headline">Uranus</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select an Animal 6">
+      <md-select-option value="lion"><div slot="headline">Lion</div></md-select-option>
+      <md-select-option value="tiger"><div slot="headline">Tiger</div></md-select-option>
+      <md-select-option value="bear"><div slot="headline">Bear</div></md-select-option>
+      <md-select-option value="elephant"><div slot="headline">Elephant</div></md-select-option>
+      <md-select-option value="giraffe"><div slot="headline">Giraffe</div></md-select-option>
+      <md-select-option value="zebra"><div slot="headline">Zebra</div></md-select-option>
+      <md-select-option value="monkey"><div slot="headline">Monkey</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a City 7">
+      <md-select-option value="new-york"><div slot="headline">New York</div></md-select-option>
+      <md-select-option value="london"><div slot="headline">London</div></md-select-option>
+      <md-select-option value="paris"><div slot="headline">Paris</div></md-select-option>
+      <md-select-option value="tokyo"><div slot="headline">Tokyo</div></md-select-option>
+      <md-select-option value="sydney"><div slot="headline">Sydney</div></md-select-option>
+      <md-select-option value="dubai"><div slot="headline">Dubai</div></md-select-option>
+      <md-select-option value="moscow"><div slot="headline">Moscow</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Fruit 8">
+      <md-select-option value="apple"><div slot="headline">Apple</div></md-select-option>
+      <md-select-option value="banana"><div slot="headline">Banana</div></md-select-option>
+      <md-select-option value="orange"><div slot="headline">Orange</div></md-select-option>
+      <md-select-option value="grape"><div slot="headline">Grape</div></md-select-option>
+      <md-select-option value="strawberry"><div slot="headline">Strawberry</div></md-select-option>
+      <md-select-option value="blueberry"><div slot="headline">Blueberry</div></md-select-option>
+      <md-select-option value="mango"><div slot="headline">Mango</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Color 9">
+      <md-select-option value="red"><div slot="headline">Red</div></md-select-option>
+      <md-select-option value="green"><div slot="headline">Green</div></md-select-option>
+      <md-select-option value="blue"><div slot="headline">Blue</div></md-select-option>
+      <md-select-option value="yellow"><div slot="headline">Yellow</div></md-select-option>
+      <md-select-option value="purple"><div slot="headline">Purple</div></md-select-option>
+      <md-select-option value="orange"><div slot="headline">Orange</div></md-select-option>
+      <md-select-option value="black"><div slot="headline">Black</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Planet 10">
+      <md-select-option value="mercury"><div slot="headline">Mercury</div></md-select-option>
+      <md-select-option value="venus"><div slot="headline">Venus</div></md-select-option>
+      <md-select-option value="earth"><div slot="headline">Earth</div></md-select-option>
+      <md-select-option value="mars"><div slot="headline">Mars</div></md-select-option>
+      <md-select-option value="jupiter"><div slot="headline">Jupiter</div></md-select-option>
+      <md-select-option value="saturn"><div slot="headline">Saturn</div></md-select-option>
+      <md-select-option value="uranus"><div slot="headline">Uranus</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select an Animal 11">
+      <md-select-option value="lion"><div slot="headline">Lion</div></md-select-option>
+      <md-select-option value="tiger"><div slot="headline">Tiger</div></md-select-option>
+      <md-select-option value="bear"><div slot="headline">Bear</div></md-select-option>
+      <md-select-option value="elephant"><div slot="headline">Elephant</div></md-select-option>
+      <md-select-option value="giraffe"><div slot="headline">Giraffe</div></md-select-option>
+      <md-select-option value="zebra"><div slot="headline">Zebra</div></md-select-option>
+      <md-select-option value="monkey"><div slot="headline">Monkey</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a City 12">
+      <md-select-option value="new-york"><div slot="headline">New York</div></md-select-option>
+      <md-select-option value="london"><div slot="headline">London</div></md-select-option>
+      <md-select-option value="paris"><div slot="headline">Paris</div></md-select-option>
+      <md-select-option value="tokyo"><div slot="headline">Tokyo</div></md-select-option>
+      <md-select-option value="sydney"><div slot="headline">Sydney</div></md-select-option>
+      <md-select-option value="dubai"><div slot="headline">Dubai</div></md-select-option>
+      <md-select-option value="moscow"><div slot="headline">Moscow</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Fruit 13">
+      <md-select-option value="apple"><div slot="headline">Apple</div></md-select-option>
+      <md-select-option value="banana"><div slot="headline">Banana</div></md-select-option>
+      <md-select-option value="orange"><div slot="headline">Orange</div></md-select-option>
+      <md-select-option value="grape"><div slot="headline">Grape</div></md-select-option>
+      <md-select-option value="strawberry"><div slot="headline">Strawberry</div></md-select-option>
+      <md-select-option value="blueberry"><div slot="headline">Blueberry</div></md-select-option>
+      <md-select-option value="mango"><div slot="headline">Mango</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Color 14">
+      <md-select-option value="red"><div slot="headline">Red</div></md-select-option>
+      <md-select-option value="green"><div slot="headline">Green</div></md-select-option>
+      <md-select-option value="blue"><div slot="headline">Blue</div></md-select-option>
+      <md-select-option value="yellow"><div slot="headline">Yellow</div></md-select-option>
+      <md-select-option value="purple"><div slot="headline">Purple</div></md-select-option>
+      <md-select-option value="orange"><div slot="headline">Orange</div></md-select-option>
+      <md-select-option value="black"><div slot="headline">Black</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Planet 15">
+      <md-select-option value="mercury"><div slot="headline">Mercury</div></md-select-option>
+      <md-select-option value="venus"><div slot="headline">Venus</div></md-select-option>
+      <md-select-option value="earth"><div slot="headline">Earth</div></md-select-option>
+      <md-select-option value="mars"><div slot="headline">Mars</div></md-select-option>
+      <md-select-option value="jupiter"><div slot="headline">Jupiter</div></md-select-option>
+      <md-select-option value="saturn"><div slot="headline">Saturn</div></md-select-option>
+      <md-select-option value="uranus"><div slot="headline">Uranus</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select an Animal 16">
+      <md-select-option value="lion"><div slot="headline">Lion</div></md-select-option>
+      <md-select-option value="tiger"><div slot="headline">Tiger</div></md-select-option>
+      <md-select-option value="bear"><div slot="headline">Bear</div></md-select-option>
+      <md-select-option value="elephant"><div slot="headline">Elephant</div></md-select-option>
+      <md-select-option value="giraffe"><div slot="headline">Giraffe</div></md-select-option>
+      <md-select-option value="zebra"><div slot="headline">Zebra</div></md-select-option>
+      <md-select-option value="monkey"><div slot="headline">Monkey</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a City 17">
+      <md-select-option value="new-york"><div slot="headline">New York</div></md-select-option>
+      <md-select-option value="london"><div slot="headline">London</div></md-select-option>
+      <md-select-option value="paris"><div slot="headline">Paris</div></md-select-option>
+      <md-select-option value="tokyo"><div slot="headline">Tokyo</div></md-select-option>
+      <md-select-option value="sydney"><div slot="headline">Sydney</div></md-select-option>
+      <md-select-option value="dubai"><div slot="headline">Dubai</div></md-select-option>
+      <md-select-option value="moscow"><div slot="headline">Moscow</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Fruit 18">
+      <md-select-option value="apple"><div slot="headline">Apple</div></md-select-option>
+      <md-select-option value="banana"><div slot="headline">Banana</div></md-select-option>
+      <md-select-option value="orange"><div slot="headline">Orange</div></md-select-option>
+      <md-select-option value="grape"><div slot="headline">Grape</div></md-select-option>
+      <md-select-option value="strawberry"><div slot="headline">Strawberry</div></md-select-option>
+      <md-select-option value="blueberry"><div slot="headline">Blueberry</div></md-select-option>
+      <md-select-option value="mango"><div slot="headline">Mango</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Color 19">
+      <md-select-option value="red"><div slot="headline">Red</div></md-select-option>
+      <md-select-option value="green"><div slot="headline">Green</div></md-select-option>
+      <md-select-option value="blue"><div slot="headline">Blue</div></md-select-option>
+      <md-select-option value="yellow"><div slot="headline">Yellow</div></md-select-option>
+      <md-select-option value="purple"><div slot="headline">Purple</div></md-select-option>
+      <md-select-option value="orange"><div slot="headline">Orange</div></md-select-option>
+      <md-select-option value="black"><div slot="headline">Black</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Planet 20">
+      <md-select-option value="mercury"><div slot="headline">Mercury</div></md-select-option>
+      <md-select-option value="venus"><div slot="headline">Venus</div></md-select-option>
+      <md-select-option value="earth"><div slot="headline">Earth</div></md-select-option>
+      <md-select-option value="mars"><div slot="headline">Mars</div></md-select-option>
+      <md-select-option value="jupiter"><div slot="headline">Jupiter</div></md-select-option>
+      <md-select-option value="saturn"><div slot="headline">Saturn</div></md-select-option>
+      <md-select-option value="uranus"><div slot="headline">Uranus</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select an Animal 21">
+      <md-select-option value="lion"><div slot="headline">Lion</div></md-select-option>
+      <md-select-option value="tiger"><div slot="headline">Tiger</div></md-select-option>
+      <md-select-option value="bear"><div slot="headline">Bear</div></md-select-option>
+      <md-select-option value="elephant"><div slot="headline">Elephant</div></md-select-option>
+      <md-select-option value="giraffe"><div slot="headline">Giraffe</div></md-select-option>
+      <md-select-option value="zebra"><div slot="headline">Zebra</div></md-select-option>
+      <md-select-option value="monkey"><div slot="headline">Monkey</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a City 22">
+      <md-select-option value="new-york"><div slot="headline">New York</div></md-select-option>
+      <md-select-option value="london"><div slot="headline">London</div></md-select-option>
+      <md-select-option value="paris"><div slot="headline">Paris</div></md-select-option>
+      <md-select-option value="tokyo"><div slot="headline">Tokyo</div></md-select-option>
+      <md-select-option value="sydney"><div slot="headline">Sydney</div></md-select-option>
+      <md-select-option value="dubai"><div slot="headline">Dubai</div></md-select-option>
+      <md-select-option value="moscow"><div slot="headline">Moscow</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Fruit 23">
+      <md-select-option value="apple"><div slot="headline">Apple</div></md-select-option>
+      <md-select-option value="banana"><div slot="headline">Banana</div></md-select-option>
+      <md-select-option value="orange"><div slot="headline">Orange</div></md-select-option>
+      <md-select-option value="grape"><div slot="headline">Grape</div></md-select-option>
+      <md-select-option value="strawberry"><div slot="headline">Strawberry</div></md-select-option>
+      <md-select-option value="blueberry"><div slot="headline">Blueberry</div></md-select-option>
+      <md-select-option value="mango"><div slot="headline">Mango</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Color 24">
+      <md-select-option value="red"><div slot="headline">Red</div></md-select-option>
+      <md-select-option value="green"><div slot="headline">Green</div></md-select-option>
+      <md-select-option value="blue"><div slot="headline">Blue</div></md-select-option>
+      <md-select-option value="yellow"><div slot="headline">Yellow</div></md-select-option>
+      <md-select-option value="purple"><div slot="headline">Purple</div></md-select-option>
+      <md-select-option value="orange"><div slot="headline">Orange</div></md-select-option>
+      <md-select-option value="black"><div slot="headline">Black</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Planet 25">
+      <md-select-option value="mercury"><div slot="headline">Mercury</div></md-select-option>
+      <md-select-option value="venus"><div slot="headline">Venus</div></md-select-option>
+      <md-select-option value="earth"><div slot="headline">Earth</div></md-select-option>
+      <md-select-option value="mars"><div slot="headline">Mars</div></md-select-option>
+      <md-select-option value="jupiter"><div slot="headline">Jupiter</div></md-select-option>
+      <md-select-option value="saturn"><div slot="headline">Saturn</div></md-select-option>
+      <md-select-option value="uranus"><div slot="headline">Uranus</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select an Animal 26">
+      <md-select-option value="lion"><div slot="headline">Lion</div></md-select-option>
+      <md-select-option value="tiger"><div slot="headline">Tiger</div></md-select-option>
+      <md-select-option value="bear"><div slot="headline">Bear</div></md-select-option>
+      <md-select-option value="elephant"><div slot="headline">Elephant</div></md-select-option>
+      <md-select-option value="giraffe"><div slot="headline">Giraffe</div></md-select-option>
+      <md-select-option value="zebra"><div slot="headline">Zebra</div></md-select-option>
+      <md-select-option value="monkey"><div slot="headline">Monkey</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a City 27">
+      <md-select-option value="new-york"><div slot="headline">New York</div></md-select-option>
+      <md-select-option value="london"><div slot="headline">London</div></md-select-option>
+      <md-select-option value="paris"><div slot="headline">Paris</div></md-select-option>
+      <md-select-option value="tokyo"><div slot="headline">Tokyo</div></md-select-option>
+      <md-select-option value="sydney"><div slot="headline">Sydney</div></md-select-option>
+      <md-select-option value="dubai"><div slot="headline">Dubai</div></md-select-option>
+      <md-select-option value="moscow"><div slot="headline">Moscow</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Fruit 28">
+      <md-select-option value="apple"><div slot="headline">Apple</div></md-select-option>
+      <md-select-option value="banana"><div slot="headline">Banana</div></md-select-option>
+      <md-select-option value="orange"><div slot="headline">Orange</div></md-select-option>
+      <md-select-option value="grape"><div slot="headline">Grape</div></md-select-option>
+      <md-select-option value="strawberry"><div slot="headline">Strawberry</div></md-select-option>
+      <md-select-option value="blueberry"><div slot="headline">Blueberry</div></md-select-option>
+      <md-select-option value="mango"><div slot="headline">Mango</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Color 29">
+      <md-select-option value="red"><div slot="headline">Red</div></md-select-option>
+      <md-select-option value="green"><div slot="headline">Green</div></md-select-option>
+      <md-select-option value="blue"><div slot="headline">Blue</div></md-select-option>
+      <md-select-option value="yellow"><div slot="headline">Yellow</div></md-select-option>
+      <md-select-option value="purple"><div slot="headline">Purple</div></md-select-option>
+      <md-select-option value="orange"><div slot="headline">Orange</div></md-select-option>
+      <md-select-option value="black"><div slot="headline">Black</div></md-select-option>
+    </md-outlined-select>
+
+    <md-outlined-select label="Select a Planet 30">
+      <md-select-option value="mercury"><div slot="headline">Mercury</div></md-select-option>
+      <md-select-option value="venus"><div slot="headline">Venus</div></md-select-option>
+      <md-select-option value="earth"><div slot="headline">Earth</div></md-select-option>
+      <md-select-option value="mars"><div slot="headline">Mars</div></md-select-option>
+      <md-select-option value="jupiter"><div slot="headline">Jupiter</div></md-select-option>
+      <md-select-option value="saturn"><div slot="headline">Saturn</div></md-select-option>
+      <md-select-option value="uranus"><div slot="headline">Uranus</div></md-select-option>
+    </md-outlined-select>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a new HTML file containing 30 dropdown menus styled with Material Design.

- Creates a new `assets` directory.
- Adds `assets/dropdowns.html` with 30 dropdowns.
- Each dropdown contains 7 items with sample data (animals, cities, etc.).
- Uses Material Web Components via a CDN for styling and functionality.